### PR TITLE
Handle imgui with 16bits and 32bits indices

### DIFF
--- a/ImWindowBGFX/ImwPlatformWindowBGFX.h
+++ b/ImWindowBGFX/ImwPlatformWindowBGFX.h
@@ -55,6 +55,9 @@ namespace ImWindow
 		bgfx::VertexDecl					m_oVertexDecl;
 		bgfx::ProgramHandle					m_hProgram;
 		bgfx::UniformHandle					m_hUniformTexture;
+
+		bgfx::DynamicVertexBufferHandle		m_hVertexBuffer;
+		bgfx::DynamicIndexBufferHandle		m_hIndexBuffer;
 	};
 }
 


### PR DESCRIPTION
Currently the bgfx backend uses "transient buffers" that only handles 16bits indices.
I modified it to use one dynamic vertex/index buffer per window to handle 16/32bits indices.